### PR TITLE
Use locale C for timestamp field.

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -201,6 +201,7 @@ save.dta13 <- function(data, file="path", data.label=NULL, time.stamp=TRUE,
   if (!time.stamp) {
     attr(data, "timestamp") <- ""
   } else {
+    lct <- Sys.getlocale("LC_TIME"); Sys.setlocale("LC_TIME", "C")
     attr(data, "timestamp") <- format(Sys.time(), "%d %b %Y %H:%M")
   }
 


### PR DESCRIPTION
Without this fix localised R installations can write timestamps with 18 characters. Stata and readstata13 will refuse to read such a file. If this occured to you please contact me.