### PR TITLE
fix strl reading and writing for big endian. fixes #83

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // stata_read
 List stata_read(const char * filePath, const bool missing, const IntegerVector selectrows, const CharacterVector selectcols, const bool strlexport, const CharacterVector strlpath);
 RcppExport SEXP _readstata13_stata_read(SEXP filePathSEXP, SEXP missingSEXP, SEXP selectrowsSEXP, SEXP selectcolsSEXP, SEXP strlexportSEXP, SEXP strlpathSEXP) {

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -207,7 +207,7 @@ List read_data(FILE * file,
 
         // FixMe: works if we read a big-endian file on little-endian
         if (byteorder.compare("MSF")==0) {
-          v = (z >> 48) & ((1 << 24) - 1);
+          v = (z >> 40) & ((1 << 24) - 1);
           o = z & ((1 << 24) - 1);
         }
 

--- a/src/save_dta.cpp
+++ b/src/save_dta.cpp
@@ -483,13 +483,13 @@ int stata_save(const char * filePath, Rcpp::DataFrame dat)
             char    z[8];
 
             // push back every v, o and val_strl
-            V.push_back(v);
+            V.push_back(v); if (swapit) v = swap_endian(v);
             O.push_back(o);
 
             // z is 'vv-- ----'
             memcpy(&z[0], &v, sizeof(v));
             if (SBYTEORDER == 1) {
-              o <<= 16;
+              o <<= 16; if (swapit) o = swap_endian(o);
             }
             memcpy(&z[2], &o, 6);
             // z is 'vvoo oooo'
@@ -509,10 +509,13 @@ int stata_save(const char * filePath, Rcpp::DataFrame dat)
             V.push_back(v);
             O.push_back(o);
 
-            // z is 'vv-- ----'
-            memcpy(&z[0], &v, sizeof(v));
+            // z is 'vvv- ----'
             if (SBYTEORDER == 1) {
-              o <<= 24;
+              v <<= 8; if (swapit) v = swap_endian(v);
+            }
+            memcpy(&z[0], &v, 3);
+            if (SBYTEORDER == 1) {
+              o <<= 24; if (swapit) o = swap_endian(o);
             }
             memcpy(&z[3], &o, 5);
             // z is 'vvvo oooo'

--- a/src/save_dta.cpp
+++ b/src/save_dta.cpp
@@ -20,6 +20,16 @@
 using namespace Rcpp;
 using namespace std;
 
+// // create big endian file from little endian
+// #ifdef swapit
+// #undef swapit
+// #undef sbyteorder
+// #undef SBYTEORDER
+// #define swapit TRUE
+// #define sbyteorder "MSF"
+// #define SBYTEORDER 1
+// #endif
+
 // Writes the binary Stata file
 //
 // @param filePath The full systempath to the dta file you want to export.


### PR DESCRIPTION
This impacts only dta format 119 and only in combination with big endian.